### PR TITLE
feat: carding internal implementation

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,6 +3,9 @@ module.exports = {
   description: 'Offical blog plugin for VuePress',
   themeConfig: {
     repo: 'ulivz/vuepress-plugin-blog',
+    nav: [
+      { text: 'Config', link: '/config/' }
+    ]
   }
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ sidebar: auto
 
 # @vuepress/plugin-blog
 
-> Official blog plugin for VuePress. 
+> Official blog plugin for VuePress.
 
 Note that this plugin has been deeply integrated into [@vuepress/theme-blog](https://github.com/ulivz/vuepress-theme-blog).
 
@@ -19,7 +19,12 @@ yarn add -D @vuepress/plugin-blog
 
 ```javascript
 module.exports = {
-  plugins: ['@vuepress/blog', { /* options */ }] 
+  plugins: [
+    '@vuepress/blog',
+    {
+      /* options */
+    },
+  ],
   // Please keep looking down to see the available options.
 }
 ```
@@ -31,13 +36,12 @@ module.exports = {
 `Document classifier` is a set of functions that can classify pages with the same characteristics. For a blog developer, the same characteristics may exist between different pages as follows:
 
 - Pages put in a directory (e.g. `_post`)
-- Pages containing the same specific frontmatter key value (e.g. `tag: js`). 
+- Pages containing the same specific frontmatter key value (e.g. `tag: js`).
 
-Of course, both of them may be related to another common 
+Of course, both of them may be related to another common
 requirement, `pagination`.
 
 So, how to combine them skillfully? Next, let's take a look at how this plugin solve these problems.
-
 
 ### Directory Classifier
 
@@ -45,11 +49,9 @@ Directory Classifier, that classifies the source pages placed in a same director
 
 Suppose you have the following files structure:
 
-``` vue
-.
-└── _posts
-    ├── 2018-4-4-intro-to-vuepress.md
-    └── 2019-6-8-intro-to-vuepress-next.md
+```vue
+. └── _posts    ├── 2018-4-4-intro-to-vuepress.md    └──
+2019-6-8-intro-to-vuepress-next.md
 ```
 
 In the traditional VuePress site, the converted page URLs will be:
@@ -63,33 +65,36 @@ It doesn't seem blogging, so it's time to use this plugin:
 // .vuepress/config.js
 module.exports = {
   plugins: [
-    ['@vuepress/blog', {
-      directories: [
-        {
-          // Unique ID of current classification
-          id: 'post',
-          // Target directory
-          dirname: '_posts',
-          // Path of the `entry page` (or `list page`)
-          path: '/',
-        },
-      ],
-    }]
-  ]
+    [
+      '@vuepress/blog',
+      {
+        directories: [
+          {
+            // Unique ID of current classification
+            id: 'post',
+            // Target directory
+            dirname: '_posts',
+            // Path of the `entry page` (or `list page`)
+            path: '/',
+          },
+        ],
+      },
+    ],
+  ],
 }
 ```
 
-Then the plugin will help you to generate following pages, and automatically leverage corresponding 
+Then the plugin will help you to generate following pages, and automatically leverage corresponding
 layout:
 
-| url | layout |
-|---|---|
-| `/` | `IndexPost` / `Layout` |
-| `/2018/04/04/intro-to-vuepress/` | `Post` |
-| `/2019/06/08/intro-to-vuepress-next/` | `Post` |
+| url                                   | layout                 |
+| ------------------------------------- | ---------------------- |
+| `/`                                   | `IndexPost` / `Layout` |
+| `/2018/04/04/intro-to-vuepress/`      | `Post`                 |
+| `/2019/06/08/intro-to-vuepress-next/` | `Post`                 |
 
 This means that you need to create two layout components(`IndexPost` and `Post`) to handle the layout of index and post
-pages. 
+pages.
 
 You can also custom the layout component name:
 
@@ -134,7 +139,7 @@ module.exports = {
 ```
 
 ::: warning
-It is noteworthy that the `path` and `itemPermalink` must be uniformly modified, and `itemPermalink` must be prefixed with 
+It is noteworthy that the `path` and `itemPermalink` must be uniformly modified, and `itemPermalink` must be prefixed with
 `path`.
 
 The default value of `itemPermalink` is `'/:year/:month/:day/:slug'`.
@@ -143,8 +148,8 @@ The default value of `itemPermalink` is `'/:year/:month/:day/:slug'`.
 ### Pagination
 
 As your blog articles grew more and more, you began to have the need for paging. By default, this plugin integrates a
- very powerful pagination system that allows you to access paging functions with simple configuration.
- 
+very powerful pagination system that allows you to access paging functions with simple configuration.
+
 By default, the plugin assumes that the max number of pages per page is `10`. you can also modify it like this:
 
 ```diff
@@ -175,23 +180,23 @@ Suppose you have 3 pages at `_posts` direcotry:
 
 When the `perPagePosts` is set to `2`, this plugin will help you generate the following pages:
 
-| url | layout |
-|---|---|
-| `/` | `IndexPost` / `Layout` |
+| url              | layout                           |
+| ---------------- | -------------------------------- |
+| `/`              | `IndexPost` / `Layout`           |
 | `/page/2/` (New) | `DirectoryPagination` / `Layout` |
-| `/2019/06/08/a/` | `Post` |
-| `/2019/06/08/b/` | `Post` |
-| `/2018/06/08/c/` | `Post` |
+| `/2019/06/08/a/` | `Post`                           |
+| `/2019/06/08/b/` | `Post`                           |
+| `/2018/06/08/c/` | `Post`                           |
 
-::: tip 
+::: tip
 `DirectoryPagination / Layout` means that the layout component will be downgraded to `Layout` when `DirectoryPagination` layout doesn't exist.
-::: 
+:::
 
 So how to get the matched pages in the layout component? In fact, it will be much simpler than you think.
 
 If you visit `/`, current page leverages layout `IndexPost`. In this layout component, you just need to use
 `this.$pagination.pages` to get the matched pages. In the above example, the actual value of `this.$pagination.pages` will
- be:
+be:
 
 ```json
 [
@@ -211,12 +216,10 @@ If you visit `/`, current page leverages layout `DirectoryPagination`, you can a
 
 Isn't this very natural experience? You just need to care about the style of your layout component, not the complicated and boring logic behind it.
 
-
 ::: tip
 To save the length of docs, we omitted the data structure of the `$page` object. You can get more information about
 the data structure of `$page` at the [official documentation](https://v1.vuepress.vuejs.org/guide/global-computed.html#page).
 :::
-
 
 ### Frontmatter Classifier
 
@@ -253,32 +256,35 @@ If you want to easily classify them, you can config like this:
 ```js
 module.exports = {
   plugins: [
-    ['@vuepress/blog', {
-      frontmatters: [
-        {
-          // Unique ID of current classification
-          id: "tag",
-          // Decide that the frontmatter keys will be grouped under this classification
-          keys: ['tag'],
-          // Path of the `entry page` (or `list page`)
-          path: '/tag/',
-          // Layout of the `entry page`
-          layout: 'Tag',
-        },
-      ]
-    }]
-  ]
+    [
+      '@vuepress/blog',
+      {
+        frontmatters: [
+          {
+            // Unique ID of current classification
+            id: 'tag',
+            // Decide that the frontmatter keys will be grouped under this classification
+            keys: ['tag'],
+            // Path of the `entry page` (or `list page`)
+            path: '/tag/',
+            // Layout of the `entry page`
+            layout: 'Tag',
+          },
+        ],
+      },
+    ],
+  ],
 }
 ```
 
 Then the plugin will help you to generate the following extra pages, and automatically leverage
 the corresponding layout:
 
-| url | layout |
-|---|---|
-| `/tag/` | `Tag` |
+| url         | layout                             |
+| ----------- | ---------------------------------- |
+| `/tag/`     | `Tag`                              |
 | `/tag/vue/` | `FrontmatterPagination` / `Layout` |
-| `/tag/js/` | `FrontmatterPagination` / `Layout` |
+| `/tag/js/`  | `FrontmatterPagination` / `Layout` |
 
 In the `Tags` component, you can use `this.$tag.list` to get the tag list. The value would be like:
 
@@ -302,9 +308,9 @@ In the `Tags` component, you can use `this.$tag.list` to get the tag list. The v
 ]
 ```
 
-In the `FrontmatterPagination` component, you can use `this.$pagination.pages` to get the matched pages in current tag 
+In the `FrontmatterPagination` component, you can use `this.$pagination.pages` to get the matched pages in current tag
 classification:
- 
+
 - If you visit `/tag/vue/`, the `this.$pagination.pages` will be:
 
 ```json
@@ -322,7 +328,6 @@ classification:
 ]
 ```
 
-
 ## Examples
 
 Actually, there are only 2 necessary layout components to create a blog theme:
@@ -332,17 +337,3 @@ Actually, there are only 2 necessary layout components to create a blog theme:
 - Tag (Only required when you set up a `tag` frontmatter classification.)
 
 Here is [live example](https://github.com/ulivz/70-lines-of-vuepress-blog-theme) that implements a functionally qualified VuePress theme in around 70 lines.
-
-## Options
-
-### directories
-
-> TODO, contribution welcome.
-
-### frontmatters
-
-> TODO, contribution welcome.
-
-
-
-

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1,0 +1,106 @@
+---
+sidebar: auto
+---
+
+# Config
+
+## directories
+
+- Type: `DirectoryClassifier[]`
+- Default: `[]`
+
+Create one or more [directory classifiers](../README.md#directory-classifier), all available options in
+`DirectoryClassifier` are as
+follows.
+
+### id
+
+- Type: `string`
+- Default: `undefined`
+- Required: `true`
+
+Unique id for current classifier, e.g. `post`.
+
+### dirname
+
+- Type: `string`
+- Default: `undefined`
+- Required: `true`
+
+Matched directory name, e.g. `_post`.
+
+### path
+
+- Type: `string`
+- Default: `/${id}/`
+- Required: `false`
+
+Entry page for current classifier, e.g. `/` or `/post/`.
+
+If you set `DirectoryClassifier.path` to `/`, it means that you want to access the matched pages list at `/`. set
+to `/post/` is the same.
+
+### layout
+
+- Type: `string`
+- Default: `'IndexPost' || 'Layout'`
+- Required: `false`
+
+Layout component name for entry page.
+
+### frontmatter
+
+- Type: `Record<string, any>`
+- Default: `{}`
+- Required: `false`
+
+[Frontmatter](https://v1.vuepress.vuejs.org/guide/frontmatter.html) for entry page.
+
+### itemLayout
+
+- Type: `string`
+- Default: `'Post'`
+- Required: `false`
+
+Layout for matched pages.
+
+### itemPermalink
+
+- Type: `string`
+- Default: `'/:year/:month/:day/:slug'`
+- Required: `false`
+
+Permalink for matched pages.
+
+For example, if you set up a directory classifier with dirname equals to `_post`, and have following pages:
+
+```
+.
+└── _posts
+    ├── 2018-4-4-intro-to-vuepress.md
+    └── 2019-6-8-intro-to-vuepress-next.md
+```
+
+With the default `itemPermalink`, you'll get following output paths:
+
+```
+/2018/04/04/intro-to-vuepress/
+/2019/06/08/intro-to-vuepress-next/
+```
+
+For more details about permalinks, please head to [Permalinks](https://v1.vuepress.vuejs.org/guide/permalinks.html) section at VuePress's documentation.
+
+### pagination
+
+- Type: `Pagination`
+- Default: `{ perPagePosts: 10 }`
+- Required: `false`
+
+All available options of pagination are as follows:
+
+- pagination.perPagePosts: Maximum number of posts per page.
+- pagination.pagesSorter: Maximum number of posts per page.
+
+## frontmatters
+
+> TODO, contribution welcome.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Offical blog plugin for VuePress",
   "scripts": {
     "lint": "xo",
-    "dev": "tsc -skipLibCheck --watch",
+    "dev": "npm run cpc && tsc -skipLibCheck --watch",
     "cpc": "cp -r src/client lib",
     "build": "tsc -skipLibCheck && npm run cpc",
     "dev:docs": "vuepress dev docs --temp docs/.temp",
@@ -26,21 +26,22 @@
   "author": "ULIVZ <chl814@foxmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "xo": "^0.23.0",
-    "prettier": "^1.15.2",
-    "eslint-config-rem": "^4.0.0",
+    "conventional-changelog-cli": "^2.0.1",
     "eslint-config-prettier": "^3.3.0",
-    "eslint-plugin-prettier": "^3.0.0",
+    "eslint-config-rem": "^4.0.0",
     "eslint-config-xo-typescript": "^0.3.0",
+    "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-typescript": "^0.14.0",
-    "typescript-eslint-parser": "^21.0.2",
     "husky": "^1.2.0",
     "lint-staged": "^8.1.0",
     "nodemon": "^1.18.7",
+    "prettier": "^1.15.2",
     "ts-node": "^7.0.1",
     "typescript": "^3.1.4",
-    "conventional-changelog-cli": "^2.0.1",
-    "vuepress": "next"
+    "typescript-eslint-parser": "^21.0.2",
+    "vuepress": "^1.0.0",
+    "xo": "^0.23.0",
+    "vuejs-paginate": "^2.1.0"
   },
   "xo": {
     "extends": [

--- a/src/client/classification.js
+++ b/src/client/classification.js
@@ -52,7 +52,7 @@ export default ({ Vue }) => {
           return classified
         },
         [`$current${classifiedType.charAt(0).toUpperCase() +
-        classifiedType.slice(1)}`]() {
+          classifiedType.slice(1)}`]() {
           const tagName = this.$route.meta.pid
           return this[helperName].getItemByName(tagName)
         },

--- a/src/client/init.js
+++ b/src/client/init.js
@@ -1,0 +1,2 @@
+export Pagination from '../components/Pagination'
+export SimplePagination from '../components/SimplePagination'

--- a/src/client/pagination.js
+++ b/src/client/pagination.js
@@ -1,19 +1,8 @@
 import Vue from 'vue'
 import paginations from '@dynamic/vuepress_blog/paginations'
-import frontmatterClassifications from '@dynamic/vuepress_blog/frontmatterClassifications'
-import pageFilters from '@dynamic/vuepress_blog/pageFilters'
-import pageSorters from '@dynamic/vuepress_blog/pageSorters'
 import _debug from 'debug'
 
 const debug = _debug('plugin-blog:pagination')
-
-function getClientFrontmatterPageFilter(rawFilter, pid, value) {
-  // debug('getClientFrontmatterPageFilter')
-  // debug('frontmatterClassifications', frontmatterClassifications)
-  // debug('pid', pid)
-  const match = frontmatterClassifications.filter(i => i.id === pid)[0]
-  return page => rawFilter(page, match && match.keys, value)
-}
 
 class PaginationGateway {
   constructor(paginations) {
@@ -39,11 +28,7 @@ const gateway = new PaginationGateway(paginations)
 class Pagination {
   constructor(pagination, pages, route) {
     debug(pagination)
-    const { pid, id, paginationPages } = pagination
-
-    const pageFilter = getClientFrontmatterPageFilter(pageFilters[pid], pid, id)
-    const pageSorter = pageSorters[pid]
-
+    const { pages: paginationPages } = pagination
     const { path } = route
 
     for (let i = 0, l = paginationPages.length; i < l; i++) {
@@ -60,7 +45,7 @@ class Pagination {
 
     this._paginationPages = paginationPages
     this._currentPage = paginationPages[this.paginationIndex]
-    this._matchedPages = pages.filter(pageFilter).sort(pageSorter)
+    this._matchedPages = pages.filter(pagination.filter).sort(pagination.sorter)
   }
 
   setIndexPage(path) {
@@ -98,6 +83,10 @@ class Pagination {
       return this._paginationPages[this.paginationIndex + 1].path
     }
   }
+
+  getSpecificPageLink(index) {
+    return this._paginationPages[this.paginationIndex + 1].path
+  }
 }
 
 export default ({ Vue }) => {
@@ -114,11 +103,8 @@ export default ({ Vue }) => {
           return {}
         }
 
-        return this.$getPagination(
-          this.$route.meta.pid,
-          this.$route.meta.id,
-        )
+        return this.$getPagination(this.$route.meta.pid, this.$route.meta.id)
       },
-    }
+    },
   })
 }

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -1,0 +1,135 @@
+<template>
+  <paginate
+    v-model="page"
+    :page-count="$pagination.length"
+    :click-handler="clickCallback"
+    :prev-text="'Prev'"
+    :next-text="'Next'"
+    :container-class="'pagination'"
+    :page-class="'page-item'">
+  </paginate>
+</template>
+
+<script>
+  import Paginate from 'vuejs-paginate'
+  
+  export default {
+    data() {
+      return {
+        page: 0,
+      }
+    },
+    components: { Paginate },
+    methods: {
+      clickCallback(pageNum) {
+        const link = this.$pagination.getSpecificPageLink(pageNum - 1)
+        console.log(link)
+        this.$router.push(link)
+      },
+    },
+  }
+</script>
+
+<style lang="stylus">
+  .pagination {
+    display: inline-block;
+    padding-left: 0;
+    margin: 20px 0;
+    border-radius: 4px;
+  }
+  
+  .pagination > li {
+    display: inline;
+    outline none;
+  }
+  
+  .pagination > li > a,
+  .pagination > li > span {
+    transition color .2s, background-color .2s
+    outline none
+    position: relative;
+    float: left;
+    padding: 6px 12px;
+    margin-left: -1px;
+    line-height: 1.42857143;
+    color: $accentColor;
+    text-decoration: none;
+    background-color: #fff;
+    border: 1px solid #ddd;
+  }
+  .pagination > li:first-child > a,
+  .pagination > li:first-child > span {
+    margin-left: 0;
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+  }
+  .pagination > li:last-child > a,
+  .pagination > li:last-child > span {
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+  .pagination > li > a:hover,
+  .pagination > li > span:hover,
+  .pagination > li > a:focus,
+  .pagination > li > span:focus {
+    z-index: 3;
+    color: $accentColor;
+    background-color: #eee;
+    border-color: #ddd;
+  }
+  .pagination > .active > a,
+  .pagination > .active > span,
+  .pagination > .active > a:hover,
+  .pagination > .active > span:hover,
+  .pagination > .active > a:focus,
+  .pagination > .active > span:focus {
+    z-index: 2;
+    color: #fff;
+    cursor: default;
+    background-color: $accentColor;
+    border-color: $accentColor;
+  }
+  .pagination > .disabled > span,
+  .pagination > .disabled > span:hover,
+  .pagination > .disabled > span:focus,
+  .pagination > .disabled > a,
+  .pagination > .disabled > a:hover,
+  .pagination > .disabled > a:focus {
+    color: #ddd;
+    cursor: not-allowed;
+    background-color: #fff;
+    border-color: #ddd;
+  }
+  .pagination-lg > li > a,
+  .pagination-lg > li > span {
+    padding: 10px 16px;
+    font-size: 18px;
+    line-height: 1.3333333;
+  }
+  .pagination-lg > li:first-child > a,
+  .pagination-lg > li:first-child > span {
+    border-top-left-radius: 6px;
+    border-bottom-left-radius: 6px;
+  }
+  .pagination-lg > li:last-child > a,
+  .pagination-lg > li:last-child > span {
+    border-top-right-radius: 6px;
+    border-bottom-right-radius: 6px;
+  }
+  .pagination-sm > li > a,
+  .pagination-sm > li > span {
+    padding: 5px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+  }
+  .pagination-sm > li:first-child > a,
+  .pagination-sm > li:first-child > span {
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px;
+  }
+  .pagination-sm > li:last-child > a,
+  .pagination-sm > li:last-child > span {
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px;
+  }
+</style>

--- a/src/components/SimplePagination.vue
+++ b/src/components/SimplePagination.vue
@@ -1,0 +1,4 @@
+<div id="pagination">
+  <router-link v-if="$pagination.hasPrev" :to="$pagination.prevLink">Prev</router-link>
+  <router-link v-if="$pagination.hasNext" :to="$pagination.nextLink">Next</router-link>
+</div>

--- a/src/interface/Classifier.ts
+++ b/src/interface/Classifier.ts
@@ -1,3 +1,8 @@
+export enum ClassifierTypeEnum {
+  Directory = 'Directory',
+  Frontmatter = 'Frontmatter',
+}
+
 export enum DefaultLayoutEnum {
   FrontmatterPagination = 'FrontmatterPagination',
   DirectoryPagination = 'DirectoryPagination',

--- a/src/interface/Frontmatter.ts
+++ b/src/interface/Frontmatter.ts
@@ -1,5 +1,5 @@
 import { FrontmatterHandler } from '../util'
-import { PaginationConfig } from './Options'
+import { PaginationConfig } from './Pagination'
 
 export interface FrontmatterClassificationPage {
   id: string;

--- a/src/interface/Options.ts
+++ b/src/interface/Options.ts
@@ -1,19 +1,8 @@
 /**
- * Config of a Pagination
- */
-export interface PaginationConfig {
-  postsFilter?: typeof Array.prototype.filter
-  postsSorter?: typeof Array.prototype.sort
-  perPagePosts?: number
-  layout?: string
-  serverPageFilter?: any;
-  clientPageFilter?: any;
-  clientPageSorter?: any;
-}
-
-/**
  * A Directory-based Classifier
  */
+import { PaginationConfig } from './Pagination'
+
 export interface DirectoryClassifier {
   /**
    * Unique id for current classifier.
@@ -24,15 +13,15 @@ export interface DirectoryClassifier {
    */
   dirname: string;
   /**
-   * Index page for current classifier.
+   * Entry page for current classifier.
    */
   path: string;
   /**
-   * Layout for index page.
+   * Layout component name for entry page.
    */
   layout?: string;
   /**
-   * Frontmatter for index page.
+   * Frontmatter for entry page.
    */
   frontmatter?: Record<string, any>;
   /**

--- a/src/interface/Pagination.ts
+++ b/src/interface/Pagination.ts
@@ -1,11 +1,95 @@
-import { PaginationConfig } from './Options'
+/**
+ * Config of a Pagination
+ */
+import { Page } from './VuePress'
+import { ClassifierTypeEnum } from './Classifier'
 
-export interface InternalPagination {
-  pid: string;
-  id: string;
+export type PageFilter = (page: Page) => boolean
+export type PageSorter = (prev: Page, next: Page) => boolean | number
+export type GetPaginationPageUrl = (index: number) => string
+export type getPaginationPageTitle = (index: number) => string
+
+/**
+ * Pagination config options for users.
+ */
+export interface PaginationConfig {
+  /**
+   * Filter for matched pages.
+   */
+  filter?: PageFilter;
+  /**
+   * Sorter for matched pages.
+   */
+  sorter?: PageSorter;
+  /**
+   * Maximum number of posts per page.
+   */
+  lengthPerPage?: number;
+  /**
+   * Layout for pagination Page (Except the index page.)
+   */
   layout?: string;
-  meta?: Record<string, any>;
-  options: PaginationConfig;
-  getUrl: (index: number) => string;
-  getTitle?: any;
+  /**
+   * A function to get the url of pagination page dynamically.
+   */
+  getPaginationPageUrl?: GetPaginationPageUrl;
+  /**
+   * A function to get the title of pagination page dynamically.
+   */
+  getPaginationPageTitle?: getPaginationPageTitle;
+}
+
+export interface PaginationIdentity {
+  /**
+   * Generalized ID
+   */
+  pid: string;
+  /**
+   * Narrow ID
+   */
+  id: string;
+}
+
+/**
+ * Internally used fields.
+ */
+export interface InternalPagination
+  extends PaginationConfig,
+    PaginationIdentity {
+  /**
+   * Record which classfier create this pagination.
+   */
+  classifierType: ClassifierTypeEnum;
+}
+
+/**
+ * Serialized pagination, generated for front-end use
+ */
+export interface SerializedPagination extends PaginationIdentity {
+  /**
+   * Stringified filter function
+   */
+  filter: string;
+  /**
+   * Stringified sorter function
+   */
+  sorter: string;
+  /**
+   * Details under current pagination
+   */
+  pages: PaginationPage[];
+}
+
+/**
+ * Auto-generated pagination page
+ */
+interface PaginationPage {
+  /**
+   * Path of current pagination page
+   */
+  path: string;
+  /**
+   * Store the first and last page index matched
+   */
+  interval: Array<number>;
 }

--- a/src/interface/VuePress.ts
+++ b/src/interface/VuePress.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { FrontmatterClassificationPage } from './Frontmatter'
-import { InternalPagination } from './Pagination'
+import { SerializedPagination } from './Pagination'
 
 export interface Page {
   key: string;
@@ -18,7 +18,8 @@ export interface AppContext {
 
 export interface AppContext {
   frontmatterClassificationPages: FrontmatterClassificationPage[];
-  paginations: InternalPagination[];
+  serializedPaginations: SerializedPagination[];
   pageFilters: any;
   pageSorters: any;
+  getLayout: (name?: string, fallback?: string) => string | undefined;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,10 @@
 import { env } from '@vuepress/shared-utils'
+import { AppContext, Page } from './interface/VuePress'
+import { ClassifierTypeEnum, DefaultLayoutEnum } from './interface/Classifier'
+import { PaginationConfig } from './interface/Pagination'
 
 export type FrontmatterHandler = (key: string, pageKey: string) => void
+
 export interface FrontmatterTempMap {
   scope: string;
   path: string;
@@ -31,21 +35,11 @@ export function logPages(title, pages) {
     const chalk = require('chalk')
     console.log()
     console.log(chalk.cyan(`[@vuepress/plugin-blog] ====== ${title} ======`))
-    const data: any[] = [
-      ['permalink', 'meta', 'pid', 'id', 'frontmatter'],
-    ]
+    const data: any[] = [['permalink', 'meta', 'pid', 'id', 'frontmatter']]
     data.push(
-      ...pages.map(({
-        // @ts-ignore
-        path,
-        permalink,
-        meta,
-        // @ts-ignore
-        pid,
-        // @ts-ignore
-        id,
-        frontmatter,
-      }) => [
+      ...pages.map(({ // @ts-ignore
+        path, permalink, meta, pid, id, frontmatter }) => [
+        // @ts-ignore // @ts-ignore
         permalink || path || '',
         JSON.stringify(meta) || '',
         pid || '',
@@ -56,4 +50,73 @@ export function logPages(title, pages) {
     console.log(table(data))
     console.log()
   }
+}
+
+export function resolvePaginationConfig(
+  classifierType: ClassifierTypeEnum,
+  pagination = {} as PaginationConfig,
+  indexPath,
+  pid, // post / tag
+  id, // post / js
+  ctx: AppContext,
+  keys: string[] = [''], // ['js']
+) {
+  return Object.assign(
+    {},
+    {
+      lengthPerPage: 10,
+      layout: ctx.getLayout(DefaultLayoutEnum.DirectoryPagination),
+
+      getPaginationPageUrl(index) {
+        if (index === 0) {
+          return indexPath
+        }
+        return `${indexPath}page/${index + 1}/`
+      },
+
+      filter:
+        classifierType === ClassifierTypeEnum.Directory
+          ? getIdentityFilter(pid, id)
+          : getFrontmatterClassifierPageFilter(keys, id),
+
+      sorter: (prev: Page, next: Page) => {
+        const prevTime = new Date(prev.frontmatter.date).getTime()
+        const nextTime = new Date(next.frontmatter.date).getTime()
+        return prevTime - nextTime > 0 ? -1 : 1
+      },
+    },
+    pagination,
+  )
+}
+
+function getIdentityFilter(pid, id) {
+  return new Function(
+    // @ts-ignore
+    ['page'],
+    `return page.pid === ${JSON.stringify(pid)} && page.id === ${JSON.stringify(
+      id,
+    )}`,
+  )
+}
+
+function getFrontmatterClassifierPageFilter(keys, value) {
+  return new Function(
+    // @ts-ignore
+    ['page'],
+    `
+const keys = ${JSON.stringify(keys)};
+const value = ${JSON.stringify(value)};
+return keys.some(key => {
+  const _value = page.frontmatter[key]
+  if (Array.isArray(_value)) {
+    return _value.some(i => i === value)
+  }
+  return _value === value
+})
+    `,
+  )
+}
+
+export function UpperFirstChar(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1)
 }


### PR DESCRIPTION
This pull request focus on the internal pagination.

## Features

```ts
/**
 * Pagination config options for users.
 */
export interface PaginationConfig {
  /**
   * Filter for matched pages.
   */
  filter?: PageFilter;
  /**
   * Sorter for matched pages.
   */
  sorter?: PageSorter;
  /**
   * Maximum number of posts per page.
   */
  lengthPerPage?: number;
  /**
   * Layout for pagination Page (Except the index page.)
   */
  layout?: string;
  /**
   * A function to get the url of pagination page dynamically.
   */
  getPaginationPageUrl?: GetPaginationPageUrl;
  /**
   * A function to get the title of pagination page dynamically.
   */
  getPaginationPageTitle?: getPaginationPageTitle;
}
```

### Out-of-box pagination component

![image](https://user-images.githubusercontent.com/23133919/59460328-6a64d900-8e51-11e9-845f-ca87ec3e1d03.png)


## Breaking Changes:

Rename 'pagination.perPagePosts' to 'pagination.lengthPerPage'