### PR TITLE
fix: Pagination Number in Nav Change is unchanged

### DIFF
--- a/src/client/components/Pagination.vue
+++ b/src/client/components/Pagination.vue
@@ -2,7 +2,7 @@
   <component
     v-if="comp"
     :is="comp"
-    v-model="page"
+    :value="page"
     :page-count="$pagination.length"
     :click-handler="clickCallback"
     :prev-text="'Prev'"
@@ -16,21 +16,16 @@
   export default {
     data() {
       return {
-        page: 0,
         comp: null,
       }
     },
 
-    watch: {
-      $pagination() {
-        this.page = this.$pagination.paginationIndex + 1
+    computed: {
+      page() {
+        return this.$pagination.paginationIndex + 1
       }
     },
 
-    created() {
-      this.page = this.$pagination.paginationIndex + 1
-    },
-    
     mounted() {
       import(/* webpackChunkName: "vuejs-paginate" */ 'vuejs-paginate').then(comp => {
         this.comp = comp.default

--- a/src/client/components/Pagination.vue
+++ b/src/client/components/Pagination.vue
@@ -20,7 +20,13 @@
         comp: null,
       }
     },
-    
+
+    watch: {
+      $pagination() {
+        this.page = this.$pagination.paginationIndex + 1
+      }
+    },
+
     created() {
       this.page = this.$pagination.paginationIndex + 1
     },


### PR DESCRIPTION
**Summary**

Fix Pagination Number in Nav Change is unchanged
[ulivz.com](https://ulivz.com/page/2/) from `编程  page/2` to `文集` pagination number is **2**

**What kind of change does this PR introduce?** (check at least one)

- [ X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
